### PR TITLE
Add timescale directive at file start

### DIFF
--- a/top.sv
+++ b/top.sv
@@ -2,6 +2,7 @@
 //  top.v    DE2-115 + Wishbone SDRAM controller bring-up
 //===============================================================
 `default_nettype none
+`timescale 1ns/1ps
 module top
 (
     // ---- DE2-115 on-board I/O ----


### PR DESCRIPTION
## Summary
- add a `timescale 1ns/1ps` directive before `module top`
- keep existing directive near the PLL model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686896573300833292ef6e3edc078111