### PR TITLE
Wrap simple SDRAM stub in optional define

### DIFF
--- a/tb_sdram.sv
+++ b/tb_sdram.sv
@@ -93,6 +93,7 @@ generate
         );
     end
 endgenerate
+`ifdef LIGHT_SDRAM_STUB
 //----------------------------------------------------------------
     // 4. Very-light SDRAM functional stub
     //----------------------------------------------------------------
@@ -125,6 +126,7 @@ endgenerate
             dq_drive_en <= 1'b0;           // release bus afterwards
         end
     end
+`endif // LIGHT_SDRAM_STUB
 
     //----------------------------------------------------------------
     // 6. PASS / FAIL monitor & simulation stop


### PR DESCRIPTION
## Summary
- wrap the lightweight SDRAM behavioral stub with `LIGHT_SDRAM_STUB`

## Testing
- `iverilog -g2012 -o tb_sdram.out tb_sdram.sv top.sv MicronSDRAM.sv SDRAM_ctrl.sv` *(fails: explicit cast errors)*

------
https://chatgpt.com/codex/tasks/task_e_686896b35ee88332901105c70b0f8614